### PR TITLE
fix: update version_tag_prefix to include 'v'

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -34,4 +34,4 @@ config :git_ops,
   changelog_file: "CHANGELOG.md",
   repository_url: "https://github.com/NarrativeApp/enquirer",
   manage_mix_version?: true,
-  version_tag_prefix: ""
+  version_tag_prefix: "v"


### PR DESCRIPTION
This tag is done _outside_ of `git_ops`